### PR TITLE
Issue #2: ReuseBackupServerとReuseBackupClientの空のXcodeプロジェクトを作成

### DIFF
--- a/ReuseBackupClient/ReuseBackupClient.xcodeproj/project.pbxproj
+++ b/ReuseBackupClient/ReuseBackupClient.xcodeproj/project.pbxproj
@@ -1,0 +1,591 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 77;
+	objects = {
+
+/* Begin PBXContainerItemProxy section */
+		0C973FBF2E13E03000DEBDBF /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0C973FA92E13E02E00DEBDBF /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 0C973FB02E13E02E00DEBDBF;
+			remoteInfo = ReuseBackupClient;
+		};
+		0C973FC92E13E03000DEBDBF /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0C973FA92E13E02E00DEBDBF /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 0C973FB02E13E02E00DEBDBF;
+			remoteInfo = ReuseBackupClient;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXFileReference section */
+		0C973FB12E13E02E00DEBDBF /* ReuseBackupClient.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ReuseBackupClient.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		0C973FBE2E13E03000DEBDBF /* ReuseBackupClientTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ReuseBackupClientTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		0C973FC82E13E03000DEBDBF /* ReuseBackupClientUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ReuseBackupClientUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+/* End PBXFileReference section */
+
+/* Begin PBXFileSystemSynchronizedRootGroup section */
+		0C973FB32E13E02E00DEBDBF /* ReuseBackupClient */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			path = ReuseBackupClient;
+			sourceTree = "<group>";
+		};
+		0C973FC12E13E03000DEBDBF /* ReuseBackupClientTests */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			path = ReuseBackupClientTests;
+			sourceTree = "<group>";
+		};
+		0C973FCB2E13E03000DEBDBF /* ReuseBackupClientUITests */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			path = ReuseBackupClientUITests;
+			sourceTree = "<group>";
+		};
+/* End PBXFileSystemSynchronizedRootGroup section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		0C973FAE2E13E02E00DEBDBF /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		0C973FBB2E13E03000DEBDBF /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		0C973FC52E13E03000DEBDBF /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		0C973FA82E13E02E00DEBDBF = {
+			isa = PBXGroup;
+			children = (
+				0C973FB32E13E02E00DEBDBF /* ReuseBackupClient */,
+				0C973FC12E13E03000DEBDBF /* ReuseBackupClientTests */,
+				0C973FCB2E13E03000DEBDBF /* ReuseBackupClientUITests */,
+				0C973FB22E13E02E00DEBDBF /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		0C973FB22E13E02E00DEBDBF /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				0C973FB12E13E02E00DEBDBF /* ReuseBackupClient.app */,
+				0C973FBE2E13E03000DEBDBF /* ReuseBackupClientTests.xctest */,
+				0C973FC82E13E03000DEBDBF /* ReuseBackupClientUITests.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		0C973FB02E13E02E00DEBDBF /* ReuseBackupClient */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 0C973FD22E13E03000DEBDBF /* Build configuration list for PBXNativeTarget "ReuseBackupClient" */;
+			buildPhases = (
+				0C973FAD2E13E02E00DEBDBF /* Sources */,
+				0C973FAE2E13E02E00DEBDBF /* Frameworks */,
+				0C973FAF2E13E02E00DEBDBF /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			fileSystemSynchronizedGroups = (
+				0C973FB32E13E02E00DEBDBF /* ReuseBackupClient */,
+			);
+			name = ReuseBackupClient;
+			packageProductDependencies = (
+			);
+			productName = ReuseBackupClient;
+			productReference = 0C973FB12E13E02E00DEBDBF /* ReuseBackupClient.app */;
+			productType = "com.apple.product-type.application";
+		};
+		0C973FBD2E13E03000DEBDBF /* ReuseBackupClientTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 0C973FD52E13E03000DEBDBF /* Build configuration list for PBXNativeTarget "ReuseBackupClientTests" */;
+			buildPhases = (
+				0C973FBA2E13E03000DEBDBF /* Sources */,
+				0C973FBB2E13E03000DEBDBF /* Frameworks */,
+				0C973FBC2E13E03000DEBDBF /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				0C973FC02E13E03000DEBDBF /* PBXTargetDependency */,
+			);
+			fileSystemSynchronizedGroups = (
+				0C973FC12E13E03000DEBDBF /* ReuseBackupClientTests */,
+			);
+			name = ReuseBackupClientTests;
+			packageProductDependencies = (
+			);
+			productName = ReuseBackupClientTests;
+			productReference = 0C973FBE2E13E03000DEBDBF /* ReuseBackupClientTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+		0C973FC72E13E03000DEBDBF /* ReuseBackupClientUITests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 0C973FD82E13E03000DEBDBF /* Build configuration list for PBXNativeTarget "ReuseBackupClientUITests" */;
+			buildPhases = (
+				0C973FC42E13E03000DEBDBF /* Sources */,
+				0C973FC52E13E03000DEBDBF /* Frameworks */,
+				0C973FC62E13E03000DEBDBF /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				0C973FCA2E13E03000DEBDBF /* PBXTargetDependency */,
+			);
+			fileSystemSynchronizedGroups = (
+				0C973FCB2E13E03000DEBDBF /* ReuseBackupClientUITests */,
+			);
+			name = ReuseBackupClientUITests;
+			packageProductDependencies = (
+			);
+			productName = ReuseBackupClientUITests;
+			productReference = 0C973FC82E13E03000DEBDBF /* ReuseBackupClientUITests.xctest */;
+			productType = "com.apple.product-type.bundle.ui-testing";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		0C973FA92E13E02E00DEBDBF /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastSwiftUpdateCheck = 1630;
+				LastUpgradeCheck = 1630;
+				TargetAttributes = {
+					0C973FB02E13E02E00DEBDBF = {
+						CreatedOnToolsVersion = 16.3;
+					};
+					0C973FBD2E13E03000DEBDBF = {
+						CreatedOnToolsVersion = 16.3;
+						TestTargetID = 0C973FB02E13E02E00DEBDBF;
+					};
+					0C973FC72E13E03000DEBDBF = {
+						CreatedOnToolsVersion = 16.3;
+						TestTargetID = 0C973FB02E13E02E00DEBDBF;
+					};
+				};
+			};
+			buildConfigurationList = 0C973FAC2E13E02E00DEBDBF /* Build configuration list for PBXProject "ReuseBackupClient" */;
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = 0C973FA82E13E02E00DEBDBF;
+			minimizedProjectReferenceProxies = 1;
+			preferredProjectObjectVersion = 77;
+			productRefGroup = 0C973FB22E13E02E00DEBDBF /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				0C973FB02E13E02E00DEBDBF /* ReuseBackupClient */,
+				0C973FBD2E13E03000DEBDBF /* ReuseBackupClientTests */,
+				0C973FC72E13E03000DEBDBF /* ReuseBackupClientUITests */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		0C973FAF2E13E02E00DEBDBF /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		0C973FBC2E13E03000DEBDBF /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		0C973FC62E13E03000DEBDBF /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		0C973FAD2E13E02E00DEBDBF /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		0C973FBA2E13E03000DEBDBF /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		0C973FC42E13E03000DEBDBF /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		0C973FC02E13E03000DEBDBF /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 0C973FB02E13E02E00DEBDBF /* ReuseBackupClient */;
+			targetProxy = 0C973FBF2E13E03000DEBDBF /* PBXContainerItemProxy */;
+		};
+		0C973FCA2E13E03000DEBDBF /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 0C973FB02E13E02E00DEBDBF /* ReuseBackupClient */;
+			targetProxy = 0C973FC92E13E03000DEBDBF /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin XCBuildConfiguration section */
+		0C973FD02E13E03000DEBDBF /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEVELOPMENT_TEAM = U2W9UR892A;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.4;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		0C973FD12E13E03000DEBDBF /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEVELOPMENT_TEAM = U2W9UR892A;
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.4;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		0C973FD32E13E03000DEBDBF /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = U2W9UR892A;
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 17.6;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.haludoll.ReuseBackupClient;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 1;
+			};
+			name = Debug;
+		};
+		0C973FD42E13E03000DEBDBF /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = U2W9UR892A;
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 17.6;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.haludoll.ReuseBackupClient;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 1;
+			};
+			name = Release;
+		};
+		0C973FD62E13E03000DEBDBF /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = U2W9UR892A;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.6;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.haludoll.ReuseBackupClientTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 1;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/ReuseBackupClient.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/ReuseBackupClient";
+			};
+			name = Debug;
+		};
+		0C973FD72E13E03000DEBDBF /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = U2W9UR892A;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.6;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.haludoll.ReuseBackupClientTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 1;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/ReuseBackupClient.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/ReuseBackupClient";
+			};
+			name = Release;
+		};
+		0C973FD92E13E03000DEBDBF /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = U2W9UR892A;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.6;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.haludoll.ReuseBackupClientUITests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 1;
+				TEST_TARGET_NAME = ReuseBackupClient;
+			};
+			name = Debug;
+		};
+		0C973FDA2E13E03000DEBDBF /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = U2W9UR892A;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.6;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.haludoll.ReuseBackupClientUITests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 1;
+				TEST_TARGET_NAME = ReuseBackupClient;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		0C973FAC2E13E02E00DEBDBF /* Build configuration list for PBXProject "ReuseBackupClient" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				0C973FD02E13E03000DEBDBF /* Debug */,
+				0C973FD12E13E03000DEBDBF /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		0C973FD22E13E03000DEBDBF /* Build configuration list for PBXNativeTarget "ReuseBackupClient" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				0C973FD32E13E03000DEBDBF /* Debug */,
+				0C973FD42E13E03000DEBDBF /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		0C973FD52E13E03000DEBDBF /* Build configuration list for PBXNativeTarget "ReuseBackupClientTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				0C973FD62E13E03000DEBDBF /* Debug */,
+				0C973FD72E13E03000DEBDBF /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		0C973FD82E13E03000DEBDBF /* Build configuration list for PBXNativeTarget "ReuseBackupClientUITests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				0C973FD92E13E03000DEBDBF /* Debug */,
+				0C973FDA2E13E03000DEBDBF /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 0C973FA92E13E02E00DEBDBF /* Project object */;
+}

--- a/ReuseBackupClient/ReuseBackupClient/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/ReuseBackupClient/ReuseBackupClient/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ReuseBackupClient/ReuseBackupClient/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/ReuseBackupClient/ReuseBackupClient/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,35 @@
+{
+  "images" : [
+    {
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "tinted"
+        }
+      ],
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ReuseBackupClient/ReuseBackupClient/Assets.xcassets/Contents.json
+++ b/ReuseBackupClient/ReuseBackupClient/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ReuseBackupClient/ReuseBackupClient/ContentView.swift
+++ b/ReuseBackupClient/ReuseBackupClient/ContentView.swift
@@ -1,0 +1,24 @@
+//
+//  ContentView.swift
+//  ReuseBackupClient
+//
+//  Created by haludoll on 2025/07/01.
+//
+
+import SwiftUI
+
+struct ContentView: View {
+    var body: some View {
+        VStack {
+            Image(systemName: "globe")
+                .imageScale(.large)
+                .foregroundStyle(.tint)
+            Text("Hello, world!")
+        }
+        .padding()
+    }
+}
+
+#Preview {
+    ContentView()
+}

--- a/ReuseBackupClient/ReuseBackupClient/ReuseBackupClientApp.swift
+++ b/ReuseBackupClient/ReuseBackupClient/ReuseBackupClientApp.swift
@@ -1,0 +1,17 @@
+//
+//  ReuseBackupClientApp.swift
+//  ReuseBackupClient
+//
+//  Created by haludoll on 2025/07/01.
+//
+
+import SwiftUI
+
+@main
+struct ReuseBackupClientApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}

--- a/ReuseBackupClient/ReuseBackupClientTests/ReuseBackupClientTests.swift
+++ b/ReuseBackupClient/ReuseBackupClientTests/ReuseBackupClientTests.swift
@@ -1,0 +1,17 @@
+//
+//  ReuseBackupClientTests.swift
+//  ReuseBackupClientTests
+//
+//  Created by haludoll on 2025/07/01.
+//
+
+import Testing
+@testable import ReuseBackupClient
+
+struct ReuseBackupClientTests {
+
+    @Test func example() async throws {
+        // Write your test here and use APIs like `#expect(...)` to check expected conditions.
+    }
+
+}

--- a/ReuseBackupClient/ReuseBackupClientUITests/ReuseBackupClientUITests.swift
+++ b/ReuseBackupClient/ReuseBackupClientUITests/ReuseBackupClientUITests.swift
@@ -1,0 +1,41 @@
+//
+//  ReuseBackupClientUITests.swift
+//  ReuseBackupClientUITests
+//
+//  Created by haludoll on 2025/07/01.
+//
+
+import XCTest
+
+final class ReuseBackupClientUITests: XCTestCase {
+
+    override func setUpWithError() throws {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+
+        // In UI tests it is usually best to stop immediately when a failure occurs.
+        continueAfterFailure = false
+
+        // In UI tests it’s important to set the initial state - such as interface orientation - required for your tests before they run. The setUp method is a good place to do this.
+    }
+
+    override func tearDownWithError() throws {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+
+    @MainActor
+    func testExample() throws {
+        // UI tests must launch the application that they test.
+        let app = XCUIApplication()
+        app.launch()
+
+        // Use XCTAssert and related functions to verify your tests produce the correct results.
+    }
+
+    @MainActor
+    func testLaunchPerformance() throws {
+        // This measures how long it takes to launch your application.
+        measure(metrics: [XCTApplicationLaunchMetric()]) {
+            XCUIApplication().launch()
+        }
+    }
+}

--- a/ReuseBackupClient/ReuseBackupClientUITests/ReuseBackupClientUITestsLaunchTests.swift
+++ b/ReuseBackupClient/ReuseBackupClientUITests/ReuseBackupClientUITestsLaunchTests.swift
@@ -1,0 +1,33 @@
+//
+//  ReuseBackupClientUITestsLaunchTests.swift
+//  ReuseBackupClientUITests
+//
+//  Created by haludoll on 2025/07/01.
+//
+
+import XCTest
+
+final class ReuseBackupClientUITestsLaunchTests: XCTestCase {
+
+    override class var runsForEachTargetApplicationUIConfiguration: Bool {
+        true
+    }
+
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+    }
+
+    @MainActor
+    func testLaunch() throws {
+        let app = XCUIApplication()
+        app.launch()
+
+        // Insert steps here to perform after app launch but before taking a screenshot,
+        // such as logging into a test account or navigating somewhere in the app
+
+        let attachment = XCTAttachment(screenshot: app.screenshot())
+        attachment.name = "Launch Screen"
+        attachment.lifetime = .keepAlways
+        add(attachment)
+    }
+}

--- a/ReuseBackupServer/ReuseBackupServer.xcodeproj/project.pbxproj
+++ b/ReuseBackupServer/ReuseBackupServer.xcodeproj/project.pbxproj
@@ -1,0 +1,591 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 77;
+	objects = {
+
+/* Begin PBXContainerItemProxy section */
+		0C973F802E13DF3400DEBDBF /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0C973F6A2E13DF3000DEBDBF /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 0C973F712E13DF3000DEBDBF;
+			remoteInfo = ReuseBackupServer;
+		};
+		0C973F8A2E13DF3400DEBDBF /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0C973F6A2E13DF3000DEBDBF /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 0C973F712E13DF3000DEBDBF;
+			remoteInfo = ReuseBackupServer;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXFileReference section */
+		0C973F722E13DF3000DEBDBF /* ReuseBackupServer.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ReuseBackupServer.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		0C973F7F2E13DF3400DEBDBF /* ReuseBackupServerTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ReuseBackupServerTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		0C973F892E13DF3400DEBDBF /* ReuseBackupServerUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ReuseBackupServerUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+/* End PBXFileReference section */
+
+/* Begin PBXFileSystemSynchronizedRootGroup section */
+		0C973F742E13DF3000DEBDBF /* ReuseBackupServer */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			path = ReuseBackupServer;
+			sourceTree = "<group>";
+		};
+		0C973F822E13DF3400DEBDBF /* ReuseBackupServerTests */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			path = ReuseBackupServerTests;
+			sourceTree = "<group>";
+		};
+		0C973F8C2E13DF3400DEBDBF /* ReuseBackupServerUITests */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			path = ReuseBackupServerUITests;
+			sourceTree = "<group>";
+		};
+/* End PBXFileSystemSynchronizedRootGroup section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		0C973F6F2E13DF3000DEBDBF /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		0C973F7C2E13DF3400DEBDBF /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		0C973F862E13DF3400DEBDBF /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		0C973F692E13DF3000DEBDBF = {
+			isa = PBXGroup;
+			children = (
+				0C973F742E13DF3000DEBDBF /* ReuseBackupServer */,
+				0C973F822E13DF3400DEBDBF /* ReuseBackupServerTests */,
+				0C973F8C2E13DF3400DEBDBF /* ReuseBackupServerUITests */,
+				0C973F732E13DF3000DEBDBF /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		0C973F732E13DF3000DEBDBF /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				0C973F722E13DF3000DEBDBF /* ReuseBackupServer.app */,
+				0C973F7F2E13DF3400DEBDBF /* ReuseBackupServerTests.xctest */,
+				0C973F892E13DF3400DEBDBF /* ReuseBackupServerUITests.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		0C973F712E13DF3000DEBDBF /* ReuseBackupServer */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 0C973F932E13DF3400DEBDBF /* Build configuration list for PBXNativeTarget "ReuseBackupServer" */;
+			buildPhases = (
+				0C973F6E2E13DF3000DEBDBF /* Sources */,
+				0C973F6F2E13DF3000DEBDBF /* Frameworks */,
+				0C973F702E13DF3000DEBDBF /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			fileSystemSynchronizedGroups = (
+				0C973F742E13DF3000DEBDBF /* ReuseBackupServer */,
+			);
+			name = ReuseBackupServer;
+			packageProductDependencies = (
+			);
+			productName = ReuseBackupServer;
+			productReference = 0C973F722E13DF3000DEBDBF /* ReuseBackupServer.app */;
+			productType = "com.apple.product-type.application";
+		};
+		0C973F7E2E13DF3400DEBDBF /* ReuseBackupServerTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 0C973F962E13DF3400DEBDBF /* Build configuration list for PBXNativeTarget "ReuseBackupServerTests" */;
+			buildPhases = (
+				0C973F7B2E13DF3400DEBDBF /* Sources */,
+				0C973F7C2E13DF3400DEBDBF /* Frameworks */,
+				0C973F7D2E13DF3400DEBDBF /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				0C973F812E13DF3400DEBDBF /* PBXTargetDependency */,
+			);
+			fileSystemSynchronizedGroups = (
+				0C973F822E13DF3400DEBDBF /* ReuseBackupServerTests */,
+			);
+			name = ReuseBackupServerTests;
+			packageProductDependencies = (
+			);
+			productName = ReuseBackupServerTests;
+			productReference = 0C973F7F2E13DF3400DEBDBF /* ReuseBackupServerTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+		0C973F882E13DF3400DEBDBF /* ReuseBackupServerUITests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 0C973F992E13DF3400DEBDBF /* Build configuration list for PBXNativeTarget "ReuseBackupServerUITests" */;
+			buildPhases = (
+				0C973F852E13DF3400DEBDBF /* Sources */,
+				0C973F862E13DF3400DEBDBF /* Frameworks */,
+				0C973F872E13DF3400DEBDBF /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				0C973F8B2E13DF3400DEBDBF /* PBXTargetDependency */,
+			);
+			fileSystemSynchronizedGroups = (
+				0C973F8C2E13DF3400DEBDBF /* ReuseBackupServerUITests */,
+			);
+			name = ReuseBackupServerUITests;
+			packageProductDependencies = (
+			);
+			productName = ReuseBackupServerUITests;
+			productReference = 0C973F892E13DF3400DEBDBF /* ReuseBackupServerUITests.xctest */;
+			productType = "com.apple.product-type.bundle.ui-testing";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		0C973F6A2E13DF3000DEBDBF /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastSwiftUpdateCheck = 1630;
+				LastUpgradeCheck = 1630;
+				TargetAttributes = {
+					0C973F712E13DF3000DEBDBF = {
+						CreatedOnToolsVersion = 16.3;
+					};
+					0C973F7E2E13DF3400DEBDBF = {
+						CreatedOnToolsVersion = 16.3;
+						TestTargetID = 0C973F712E13DF3000DEBDBF;
+					};
+					0C973F882E13DF3400DEBDBF = {
+						CreatedOnToolsVersion = 16.3;
+						TestTargetID = 0C973F712E13DF3000DEBDBF;
+					};
+				};
+			};
+			buildConfigurationList = 0C973F6D2E13DF3000DEBDBF /* Build configuration list for PBXProject "ReuseBackupServer" */;
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = 0C973F692E13DF3000DEBDBF;
+			minimizedProjectReferenceProxies = 1;
+			preferredProjectObjectVersion = 77;
+			productRefGroup = 0C973F732E13DF3000DEBDBF /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				0C973F712E13DF3000DEBDBF /* ReuseBackupServer */,
+				0C973F7E2E13DF3400DEBDBF /* ReuseBackupServerTests */,
+				0C973F882E13DF3400DEBDBF /* ReuseBackupServerUITests */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		0C973F702E13DF3000DEBDBF /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		0C973F7D2E13DF3400DEBDBF /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		0C973F872E13DF3400DEBDBF /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		0C973F6E2E13DF3000DEBDBF /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		0C973F7B2E13DF3400DEBDBF /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		0C973F852E13DF3400DEBDBF /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		0C973F812E13DF3400DEBDBF /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 0C973F712E13DF3000DEBDBF /* ReuseBackupServer */;
+			targetProxy = 0C973F802E13DF3400DEBDBF /* PBXContainerItemProxy */;
+		};
+		0C973F8B2E13DF3400DEBDBF /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 0C973F712E13DF3000DEBDBF /* ReuseBackupServer */;
+			targetProxy = 0C973F8A2E13DF3400DEBDBF /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin XCBuildConfiguration section */
+		0C973F912E13DF3400DEBDBF /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEVELOPMENT_TEAM = U2W9UR892A;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.4;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		0C973F922E13DF3400DEBDBF /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEVELOPMENT_TEAM = U2W9UR892A;
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.4;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		0C973F942E13DF3400DEBDBF /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = U2W9UR892A;
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 15.6;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.haludoll.ReuseBackupServer;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 1;
+			};
+			name = Debug;
+		};
+		0C973F952E13DF3400DEBDBF /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = U2W9UR892A;
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 15.6;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.haludoll.ReuseBackupServer;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 1;
+			};
+			name = Release;
+		};
+		0C973F972E13DF3400DEBDBF /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = U2W9UR892A;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.6;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.haludoll.ReuseBackupServerTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 1;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/ReuseBackupServer.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/ReuseBackupServer";
+			};
+			name = Debug;
+		};
+		0C973F982E13DF3400DEBDBF /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = U2W9UR892A;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.6;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.haludoll.ReuseBackupServerTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 1;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/ReuseBackupServer.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/ReuseBackupServer";
+			};
+			name = Release;
+		};
+		0C973F9A2E13DF3400DEBDBF /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = U2W9UR892A;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.6;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.haludoll.ReuseBackupServerUITests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 1;
+				TEST_TARGET_NAME = ReuseBackupServer;
+			};
+			name = Debug;
+		};
+		0C973F9B2E13DF3400DEBDBF /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = U2W9UR892A;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.6;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.haludoll.ReuseBackupServerUITests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 1;
+				TEST_TARGET_NAME = ReuseBackupServer;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		0C973F6D2E13DF3000DEBDBF /* Build configuration list for PBXProject "ReuseBackupServer" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				0C973F912E13DF3400DEBDBF /* Debug */,
+				0C973F922E13DF3400DEBDBF /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		0C973F932E13DF3400DEBDBF /* Build configuration list for PBXNativeTarget "ReuseBackupServer" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				0C973F942E13DF3400DEBDBF /* Debug */,
+				0C973F952E13DF3400DEBDBF /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		0C973F962E13DF3400DEBDBF /* Build configuration list for PBXNativeTarget "ReuseBackupServerTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				0C973F972E13DF3400DEBDBF /* Debug */,
+				0C973F982E13DF3400DEBDBF /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		0C973F992E13DF3400DEBDBF /* Build configuration list for PBXNativeTarget "ReuseBackupServerUITests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				0C973F9A2E13DF3400DEBDBF /* Debug */,
+				0C973F9B2E13DF3400DEBDBF /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 0C973F6A2E13DF3000DEBDBF /* Project object */;
+}

--- a/ReuseBackupServer/ReuseBackupServer/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/ReuseBackupServer/ReuseBackupServer/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ReuseBackupServer/ReuseBackupServer/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/ReuseBackupServer/ReuseBackupServer/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,35 @@
+{
+  "images" : [
+    {
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "tinted"
+        }
+      ],
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ReuseBackupServer/ReuseBackupServer/Assets.xcassets/Contents.json
+++ b/ReuseBackupServer/ReuseBackupServer/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ReuseBackupServer/ReuseBackupServer/ContentView.swift
+++ b/ReuseBackupServer/ReuseBackupServer/ContentView.swift
@@ -1,0 +1,24 @@
+//
+//  ContentView.swift
+//  ReuseBackupServer
+//
+//  Created by haludoll on 2025/07/01.
+//
+
+import SwiftUI
+
+struct ContentView: View {
+    var body: some View {
+        VStack {
+            Image(systemName: "globe")
+                .imageScale(.large)
+                .foregroundStyle(.tint)
+            Text("Hello, world!")
+        }
+        .padding()
+    }
+}
+
+#Preview {
+    ContentView()
+}

--- a/ReuseBackupServer/ReuseBackupServer/ReuseBackupServerApp.swift
+++ b/ReuseBackupServer/ReuseBackupServer/ReuseBackupServerApp.swift
@@ -1,0 +1,17 @@
+//
+//  ReuseBackupServerApp.swift
+//  ReuseBackupServer
+//
+//  Created by haludoll on 2025/07/01.
+//
+
+import SwiftUI
+
+@main
+struct ReuseBackupServerApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}

--- a/ReuseBackupServer/ReuseBackupServerTests/ReuseBackupServerTests.swift
+++ b/ReuseBackupServer/ReuseBackupServerTests/ReuseBackupServerTests.swift
@@ -1,0 +1,17 @@
+//
+//  ReuseBackupServerTests.swift
+//  ReuseBackupServerTests
+//
+//  Created by haludoll on 2025/07/01.
+//
+
+import Testing
+@testable import ReuseBackupServer
+
+struct ReuseBackupServerTests {
+
+    @Test func example() async throws {
+        // Write your test here and use APIs like `#expect(...)` to check expected conditions.
+    }
+
+}

--- a/ReuseBackupServer/ReuseBackupServerUITests/ReuseBackupServerUITests.swift
+++ b/ReuseBackupServer/ReuseBackupServerUITests/ReuseBackupServerUITests.swift
@@ -1,0 +1,41 @@
+//
+//  ReuseBackupServerUITests.swift
+//  ReuseBackupServerUITests
+//
+//  Created by haludoll on 2025/07/01.
+//
+
+import XCTest
+
+final class ReuseBackupServerUITests: XCTestCase {
+
+    override func setUpWithError() throws {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+
+        // In UI tests it is usually best to stop immediately when a failure occurs.
+        continueAfterFailure = false
+
+        // In UI tests it’s important to set the initial state - such as interface orientation - required for your tests before they run. The setUp method is a good place to do this.
+    }
+
+    override func tearDownWithError() throws {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+
+    @MainActor
+    func testExample() throws {
+        // UI tests must launch the application that they test.
+        let app = XCUIApplication()
+        app.launch()
+
+        // Use XCTAssert and related functions to verify your tests produce the correct results.
+    }
+
+    @MainActor
+    func testLaunchPerformance() throws {
+        // This measures how long it takes to launch your application.
+        measure(metrics: [XCTApplicationLaunchMetric()]) {
+            XCUIApplication().launch()
+        }
+    }
+}

--- a/ReuseBackupServer/ReuseBackupServerUITests/ReuseBackupServerUITestsLaunchTests.swift
+++ b/ReuseBackupServer/ReuseBackupServerUITests/ReuseBackupServerUITestsLaunchTests.swift
@@ -1,0 +1,33 @@
+//
+//  ReuseBackupServerUITestsLaunchTests.swift
+//  ReuseBackupServerUITests
+//
+//  Created by haludoll on 2025/07/01.
+//
+
+import XCTest
+
+final class ReuseBackupServerUITestsLaunchTests: XCTestCase {
+
+    override class var runsForEachTargetApplicationUIConfiguration: Bool {
+        true
+    }
+
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+    }
+
+    @MainActor
+    func testLaunch() throws {
+        let app = XCUIApplication()
+        app.launch()
+
+        // Insert steps here to perform after app launch but before taking a screenshot,
+        // such as logging into a test account or navigating somewhere in the app
+
+        let attachment = XCTAttachment(screenshot: app.screenshot())
+        attachment.name = "Launch Screen"
+        attachment.lifetime = .keepAlways
+        add(attachment)
+    }
+}


### PR DESCRIPTION
## 概要
Issue #2で計画された古いiPhone用サーバーアプリとクライアント用アプリの空のXcodeプロジェクトを作成しました。

## 実装内容

### ReuseBackupServer
- SwiftUIベースのiOSアプリプロジェクト
- テストターゲット付き（ReuseBackupServerTests, ReuseBackupServerUITests）
- 基本的なContentViewとApp構造

### ReuseBackupClient  
- SwiftUIベースのiOSアプリプロジェクト
- テストターゲット付き（ReuseBackupClientTests, ReuseBackupClientUITests）
- 基本的なContentViewとApp構造

## 確認事項
- [x] ReuseBackupServer.xcodeproj が作成済み
- [x] ReuseBackupClient.xcodeproj が作成済み
- [x] 両プロジェクトのテストターゲットが含まれている
- [x] 基本的なSwiftUIファイル構造が配置済み

## 次のステップ
1. 両プロジェクトのビルド確認
2. 共有モデルの設計と実装
3. コアネットワーキング機能の実装

🤖 Generated with [Claude Code](https://claude.ai/code)