### PR TITLE
Issue #51: ドキュメントからFlyingFoxの文言を消す

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,7 @@ ReuseBackupは、古いiPhoneを写真・動画のローカルバックアップ
 
 - **言語**: Swift（サーバー: 5.9+、クライアント: 6.0+）
 - **フレームワーク**: 
-  - サーバー: FlyingFox HTTPサーバー、Bonjourサービス発見
+  - サーバー: HummingBird HTTPサーバー、Bonjourサービス発見
   - クライアント: SwiftUI、HTTPリクエスト用URLSession
 - **アーキテクチャ**: 単方向HTTP通信（クライアント → サーバー）
 - **プラットフォーム**: ローカル専用・プライバシー重視のiOS

--- a/HTTPAdapters/README.md
+++ b/HTTPAdapters/README.md
@@ -15,7 +15,7 @@ ReuseBackupServerアプリで直接HummingBirdを使用せず、統一された�
 
 ## 開発経緯
 
-1. **初期計画**: FlyingFox + HummingBird v1/v2の複数サーバー対応
+1. **初期計画**: HummingBird v1/v2の複数サーバー対応
 2. **アーキテクチャ変更**: iOS17+でv2、iOS15-17でv1の分離パッケージ構成を試行
 3. **依存関係問題**: Swift Package Managerの推移的依存でiOS15+とiOS17+の同時サポートが不可能と判明
 4. **最終決定**: HummingBird v1.xのみでiOS15+対応の単一パッケージに統一

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@
 
 - **通信方式**: HTTP + Bonjour
 - **通信方向**: クライアント → サーバー（一方向）
-- **古いスマホ**: FlyingFox + Network Framework (iOS 15対応)
+- **古いスマホ**: HummingBird + Network Framework (iOS 15対応)
 - **新しいスマホ**: URLSession + SwiftUI (iOS 17対応)
 
 ## 開発方針

--- a/docs/TECHNICAL_SPEC.md
+++ b/docs/TECHNICAL_SPEC.md
@@ -3,7 +3,7 @@
 ## アーキテクチャ
 
 ### 基本構成
-- **古いiPhone**: HTTPサーバー（[FlyingFox](https://github.com/swhitty/FlyingFox)）
+- **古いiPhone**: HTTPサーバー（HummingBird）
 - **新しいiPhone**: HTTPクライアント（URLSession）
 - **通信**: HTTP/1.1 + Bonjour発見
 - **方向**: クライアント → サーバー（一方向）
@@ -13,7 +13,7 @@
 ### 古いiPhone (サーバー)
 - **OS**: iOS 15+
 - **言語**: Swift 5.9+
-- **HTTPサーバー**: FlyingFox
+- **HTTPサーバー**: HummingBird
 - **サービス発見**: Network Framework (Bonjour)
 
 ### 新しいiPhone (クライアント)


### PR DESCRIPTION
FlyingFoxからHummingBirdへの移行に伴い、以下のドキュメントファイルのFlyingFoxの参照をHummingBirdに置換しました：

- docs/TECHNICAL_SPEC.md
- CLAUDE.md
- HTTPAdapters/README.md
- README.md

関連イシュー: #51

Generated with [Claude Code](https://claude.ai/code)